### PR TITLE
ci update - move new issues to triage

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,13 @@
+name: New issues into Triage
+on:
+  issues:
+    types: [opened]
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          project: Backlog
+          column: Triage
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In this PR we've:
 - Added CI GitHub actions to move new issues to triage