### PR TITLE
Tika upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,6 @@ branches:
   only:
   - master
   - /.*/
-before_install:
-  - curl -fsSL https://get.docker.com | sh
-  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
-  - mkdir -p $HOME/.docker
-  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
-  - sudo service docker start
-install:
-  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-  - docker buildx create --name xbuilder --use
 before_script:
   - echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 script:
@@ -23,10 +14,10 @@ script:
    else
      export TAG=$TRAVIS_BRANCH
    fi
-  - docker buildx build --platform linux/amd64 -t saidsef/tika-convert-to-text:$TAG --push .
-  - docker buildx build --platform linux/amd64 -t saidsef/tika-convert-to-text:server-$TAG -f Dockerfile.server --push .
-  # - docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t saidsef/tika-convert-to-text:openfaas-$TAG -f Dockerfile.faas --push .
-  - cd ../ui/ && docker buildx build --platform linux/amd64 -t saidsef/tika-convert-to-text:ui-$TAG -f Dockerfile --push .
+  - docker build -t saidsef/tika-convert-to-text:$TAG .
+  - docker build -t saidsef/tika-convert-to-text:server-$TAG -f Dockerfile.server .
+  - cd ../ui/ && docker build -t saidsef/tika-convert-to-text:ui-$TAG -f Dockerfile .
+  - docker push saidsef/tika-convert-to-text
 after_script:
   - docker images
 notifications:

--- a/deployment/ingress.yml
+++ b/deployment/ingress.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tika-ui
@@ -21,6 +21,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: ui
-          servicePort: 8080
+          service:
+            name: ui
+            port:
+              number: 8080

--- a/function/Dockerfile
+++ b/function/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-slim-stretch
 
 LABEL maintainer="Said Sef <said@saidsef.co.uk> (saidsef.co.uk/)"
 
-ENV APACHE_TIKA_VERSION 1.24.1
+ENV APACHE_TIKA_VERSION 1.25
 ENV CLASSPATH "/opt/tika/tika-app.jar:/opt/tika/libs"
 ENV SQLITE_JDBC 3.32.3
 ENV JBIG2_IMAGEIO 3.0.3

--- a/function/Dockerfile.faas
+++ b/function/Dockerfile.faas
@@ -2,7 +2,7 @@ FROM python:3-slim-stretch
 
 LABEL maintainer="Said Sef <said@saidsef.co.uk> (saidsef.co.uk/)"
 
-ENV APACHE_TIKA_VERSION 1.24.1
+ENV APACHE_TIKA_VERSION 1.25
 ENV CLASSPATH "/opt/tika/tika-app.jar:/opt/tika/libs"
 ENV SQLITE_JDBC 3.32.3
 ENV JBIG2_IMAGEIO 3.0.3

--- a/function/Dockerfile.server
+++ b/function/Dockerfile.server
@@ -2,7 +2,7 @@ FROM openjdk:8-jre-alpine
 
 LABEL maintainer="Said Sef <said@saidsef.co.uk> (saidsef.co.uk/)"
 
-ENV APACHE_TIKA_VERSION 1.24.1
+ENV APACHE_TIKA_VERSION 1.25
 ENV CLASSPATH "/opt/tika/tika-server.jar:/opt/tika/libs"
 ENV SQLITE_JDBC 3.32.3
 ENV JBIG2_IMAGEIO 3.0.3

--- a/function/Pipfile
+++ b/function/Pipfile
@@ -1,13 +1,13 @@
 [[source]]
-name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
-
-[dev-packages]
+name = "pypi"
 
 [packages]
-prometheus-flask-exporter = "==0.13.0"
+prometheus-flask-exporter = "==0.16.5"
 Flask = "==1.1.2"
+
+[dev-packages]
 
 [requires]
 python_version = "3.7"

--- a/function/Pipfile.lock
+++ b/function/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f08d9745b66c6622acdde7749d791b070f537707e65f539609f6808f5aebe033"
+            "sha256": "ce015d0f3f0c55c4727d5a350b78e4c59792558ee29b14e61ce3a7b6895046a2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -42,11 +42,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
-                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
+                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.11.2"
+            "version": "==2.11.3"
         },
         "markupsafe": {
             "hashes": [
@@ -55,8 +55,12 @@
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
                 "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
+                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
+                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
@@ -65,41 +69,56 @@
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
                 "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
                 "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
+                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
                 "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
                 "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
                 "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
                 "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
                 "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
+                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
                 "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
                 "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
                 "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
                 "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
                 "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
+                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
+                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
+                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "prometheus-client": {
             "hashes": [
-                "sha256:983c7ac4b47478720db338f1491ef67a100b474e3bc7dafcbaefb7d0b8f9b01c",
-                "sha256:c6e6b706833a6bd1fd51711299edee907857be10ece535126a158f911ee80915"
+                "sha256:9da7b32f02439d8c04f7777021c304ed51d9ec180604700c1ba72a4d44dceb03",
+                "sha256:b08c34c328e1bf5961f0b4352668e6c8f145b4a087e09b7296ef62cbe4693d35"
             ],
-            "version": "==0.8.0"
+            "version": "==0.9.0"
         },
         "prometheus-flask-exporter": {
             "hashes": [
-                "sha256:a3d7003df268ba0d91d91526ea8abee08e619c91f1fdc16de1604c196654fdee"
+                "sha256:f9d601845b3e9287120c02bf667c99f4a0caf0f4861af09c58ab3ce56c42fb8a"
             ],
             "index": "pypi",
-            "version": "==0.13.0"
+            "version": "==0.16.5"
         },
         "werkzeug": {
             "hashes": [

--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -1,3 +1,3 @@
 -i https://pypi.org/simple
 flask==1.1.2
-prometheus-flask-exporter==0.13.0
+prometheus-flask-exporter==0.16.5

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,11 +48,11 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-prometheus-middleware": "^0.9.6",
-    "helmet": "^4.0.0",
+    "helmet": "^4.4.1",
     "morgan": "^1.10.0",
     "multer": "^1.4.2",
-    "prom-client": "^11.5.3",
-    "template-literal": "^1.0.3"
+    "prom-client": "^12.0.0",
+    "template-literal": "^1.0.4"
   },
   "homepage": "https://github.com/saidsef/faas-convert-to-text#readme",
   "devDependencies": {}


### PR DESCRIPTION
In this PR we've:
- updated lib versions
- removed multi-arch build
- upgraded Tika version to 1.25
- updated K8s ingress spec